### PR TITLE
CHG - Enhanced GPU Support and Dependency Updates on docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.7'
 
 services:
   cheshire-cat-core:
-    image: ghcr.io/cheshire-cat-ai/core:1.5.1
+    image: ghcr.io/cheshire-cat-ai/core:1.5.3
     container_name: cheshire_cat_core
     depends_on:
       - cheshire-cat-vector-memory
@@ -28,7 +28,7 @@ services:
     restart: unless-stopped
 
   cheshire-cat-vector-memory:
-    image: qdrant/qdrant:v1.7.4
+    image: qdrant/qdrant:v1.9.1
     container_name: cheshire_cat_vector_memory
     expose:
       - 6333
@@ -38,7 +38,7 @@ services:
 
   ollama:
     container_name: ollama_cat
-    image: ollama/ollama:0.1.28
+    image: ollama/ollama:0.1.33
     volumes:
       - ./ollama:/root/.ollama
     expose:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.7'
 
 services:
   cheshire-cat-core:
-    image: ghcr.io/cheshire-cat-ai/core:1.5.1
+    image: ghcr.io/cheshire-cat-ai/core:1.6.1
     container_name: cheshire_cat_core
     depends_on:
       - cheshire-cat-vector-memory
@@ -28,7 +28,7 @@ services:
     restart: unless-stopped
 
   cheshire-cat-vector-memory:
-    image: qdrant/qdrant:v1.7.1
+    image: qdrant/qdrant:v1.7.4
     container_name: cheshire_cat_vector_memory
     expose:
       - 6333
@@ -38,17 +38,15 @@ services:
 
   ollama:
     container_name: ollama_cat
-    image: ollama/ollama:0.1.28
+    image: ollama/ollama:0.1.33
     volumes:
       - ./ollama:/root/.ollama
     expose:
       - 11434
-    environment:
-      - gpus=all
     deploy:
       resources:
         reservations:
           devices:
             - driver: nvidia
-              count: 1
+              count: all
               capabilities: [ gpu ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.7'
 
 services:
   cheshire-cat-core:
-    image: ghcr.io/cheshire-cat-ai/core:1.6.1
+    image: ghcr.io/cheshire-cat-ai/core:1.5.1
     container_name: cheshire_cat_core
     depends_on:
       - cheshire-cat-vector-memory
@@ -38,7 +38,7 @@ services:
 
   ollama:
     container_name: ollama_cat
-    image: ollama/ollama:0.1.33
+    image: ollama/ollama:0.1.28
     volumes:
       - ./ollama:/root/.ollama
     expose:


### PR DESCRIPTION
- **Fixed GPU allocation in Ollama**: `gpus=all` flag used in `docker run` did not affect the behavior of `docker compose`. The `nvidia-smi` inside ollama would still detect a number of GPUs equal to the number set in `count:`. 
  - Now, using `count: all` allows for dynamic detection and utilization of all available GPUs in ollama container.
- **Bumped Ollama to v0.1.33**: As it offers improved multi-GPU workload optimization and enhanced support for llama3 and mixtral.
- **Bumped Cat Core to v1.6.1**: Just to bring in the latest features and bug fixes from the Cat.
- **Bumped Qdrant to the latest patch v1.7.4**: I'm currently verifying the compatibility of Qdrant v1.9.1 with Cheshire vectorDB calls.