### PR TITLE
Feature - Docker compose and .env.example updates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,7 @@ DEBUG=false                      # Enable debugging for more verbose logs
 # Settings for Qdrant vector memory service
 # Uncomment and set the following if you need to specify custom settings
 QDRANT_HOST=cheshire_cat_vector_memory  # Hostname for the Qdrant service
+QDRANT_PORT=6333                        # Port for the Qdrant service
 
 # Feature toggles
 SAVE_MEMORY_SNAPSHOTS=false      # Toggle for saving memory snapshots on embedder change

--- a/.env.example
+++ b/.env.example
@@ -1,19 +1,21 @@
 # Decide host and port for your Cat. Default will be localhost:1865
-CORE_HOST=localhost
-CORE_PORT=1865
+# General settings for Cheshire Cat Core
+CORE_HOST=localhost              # Hostname for core service
+CORE_PORT=1865                   # Port for core service
+LOG_LEVEL=WARNING                # Default log level for all services
+DEBUG=false                      # Enable debugging for more verbose logs
+# CORE_USE_SECURE_PROTOCOLS=true  # Uncomment to enable HTTPS/WSS for secure connections
+# API_KEY=meow                    # Uncomment to set an API key for protected endpoints
 
-# Qdrant server
-# QDRANT_HOST=localhost
-# QDRANT_PORT=6333
+# Settings for Qdrant vector memory service
+# Uncomment and set the following if you need to specify custom settings
+QDRANT_HOST=cheshire_cat_vector_memory  # Hostname for the Qdrant service
+QDRANT_PORT=6333                        # External port for Qdrant service
 
-# Decide to use https / wss secure protocols
-#CORE_USE_SECURE_PROTOCOLS=true
+# Feature toggles
+SAVE_MEMORY_SNAPSHOTS=false      # Toggle for saving memory snapshots on embedder change
 
-# Protect endpoints with an access token
-#API_KEY=meow
-
-# Log levels
-LOG_LEVEL=WARNING
-
-# Turn on memory collections' snapshots on embedder change with SAVE_MEMORY_SNAPSHOTS=true
-SAVE_MEMORY_SNAPSHOTS=false
+# Ollama-specific settings
+OLLAMA_PORT=11434                # External port for Ollama service
+OLLAMA_FLASH_ATTENTION=false     # Flash attention setting for Ollama service
+OLLAMA_DEBUG=false               # Debug mode for Ollama service

--- a/.env.example
+++ b/.env.example
@@ -10,12 +10,13 @@ DEBUG=false                      # Enable debugging for more verbose logs
 # Settings for Qdrant vector memory service
 # Uncomment and set the following if you need to specify custom settings
 QDRANT_HOST=cheshire_cat_vector_memory  # Hostname for the Qdrant service
-QDRANT_PORT=6333                        # External port for Qdrant service
 
 # Feature toggles
 SAVE_MEMORY_SNAPSHOTS=false      # Toggle for saving memory snapshots on embedder change
 
 # Ollama-specific settings
-OLLAMA_PORT=11434                # External port for Ollama service
-OLLAMA_FLASH_ATTENTION=false     # Flash attention setting for Ollama service
-OLLAMA_DEBUG=false               # Debug mode for Ollama service
+OLLAMA_FLASH_ATTENTION=false         # Flash attention setting for Ollama service
+OLLAMA_DEBUG=false                   # Debug mode for Ollama service
+OLLAMA_KEEP_ALIVE="5m"               # Duration models stay loaded, default 5 minutes, can be set to e.g., "24h"
+OLLAMA_MAX_LOADED_MODELS=1           # Maximum number of models loaded simultaneously, default to 1
+OLLAMA_NUM_PARALLEL=1                # Maximum number of allocated contexts (parallel requests). Manage resource efficiently: If OLLAMA_NUM_PARALLEL=4 and OLLAMA_MAX_LOADED_MODELS=3, the total context requirement might be up to 12 (4x3)

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__/
 
 /cat/**
 /ollama/*
+.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,19 +8,19 @@ services:
       - cheshire-cat-vector-memory
       - ollama
     environment:
-      - PYTHONUNBUFFERED=1
-      - WATCHFILES_FORCE_POLLING=true
-      - CORE_HOST=${CORE_HOST:-localhost}
-      - CORE_PORT=${CORE_PORT:-1865}
-      - QDRANT_HOST=${QDRANT_HOST:-cheshire_cat_vector_memory}
-      - QDRANT_PORT=${QDRANT_PORT:-6333}
-      - CORE_USE_SECURE_PROTOCOLS=${CORE_USE_SECURE_PROTOCOLS:-}
-      - API_KEY=${API_KEY:-}
-      - LOG_LEVEL=${LOG_LEVEL:-WARNING}
-      - DEBUG=${DEBUG:-true}
-      - SAVE_MEMORY_SNAPSHOTS=${SAVE_MEMORY_SNAPSHOTS:-false}
+      PYTHONUNBUFFERED: "1"
+      WATCHFILES_FORCE_POLLING: "true"
+      CORE_HOST: ${CORE_HOST:-localhost}
+      CORE_PORT: ${CORE_PORT:-1865}
+      QDRANT_HOST: ${QDRANT_HOST:-cheshire_cat_vector_memory}
+      QDRANT_PORT: ${QDRANT_PORT:-6333}
+      CORE_USE_SECURE_PROTOCOLS: ${CORE_USE_SECURE_PROTOCOLS:-false}
+      API_KEY: ${API_KEY:-}
+      LOG_LEVEL: ${LOG_LEVEL:-WARNING}
+      DEBUG: ${DEBUG:-false}
+      SAVE_MEMORY_SNAPSHOTS: ${SAVE_MEMORY_SNAPSHOTS:-false}
     ports:
-      - ${CORE_PORT:-1865}:80
+      - "${CORE_PORT:-1865}:80"
     volumes:
       - ./cat/static:/app/cat/static
       - ./cat/plugins:/app/cat/plugins
@@ -30,23 +30,29 @@ services:
   cheshire-cat-vector-memory:
     image: qdrant/qdrant:v1.9.1
     container_name: cheshire_cat_vector_memory
-    expose:
-      - 6333
+    environment:
+      LOG_LEVEL: ${LOG_LEVEL:-WARNING}
+    ports:
+      - "${QDRANT_PORT:-6333}:6333"
     volumes:
       - ./cat/long_term_memory/vector:/qdrant/storage
     restart: unless-stopped
 
   ollama:
-    container_name: ollama_cat
     image: ollama/ollama:0.1.39
+    container_name: ollama_cat
+    environment:
+      OLLAMA_FLASH_ATTENTION: ${OLLAMA_FLASH_ATTENTION:-false}
+      OLLAMA_DEBUG: ${OLLAMA_DEBUG:-false}
+    ports:
+      - "${OLLAMA_PORT:-11434}:11434"
     volumes:
       - ./ollama:/root/.ollama
-    expose:
-      - 11434
     deploy:
       resources:
         reservations:
           devices:
             - driver: nvidia
               count: all
-              capabilities: [ gpu ]
+              capabilities: [gpu]
+    restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,8 +32,8 @@ services:
     container_name: cheshire_cat_vector_memory
     environment:
       LOG_LEVEL: ${LOG_LEVEL:-WARNING}
-    ports:
-      - "${QDRANT_PORT:-6333}:6333"
+    expose:
+      - "6333"
     volumes:
       - ./cat/long_term_memory/vector:/qdrant/storage
     restart: unless-stopped
@@ -44,8 +44,11 @@ services:
     environment:
       OLLAMA_FLASH_ATTENTION: ${OLLAMA_FLASH_ATTENTION:-false}
       OLLAMA_DEBUG: ${OLLAMA_DEBUG:-false}
-    ports:
-      - "${OLLAMA_PORT:-11434}:11434"
+      OLLAMA_KEEP_ALIVE: ${OLLAMA_KEEP_ALIVE:-"5m"}
+      OLLAMA_MAX_LOADED_MODELS: ${OLLAMA_MAX_LOADED_MODELS:-1}
+      OLLAMA_NUM_PARALLEL: ${OLLAMA_NUM_PARALLEL:-1}
+    expose:
+      - "11434"
     volumes:
       - ./ollama:/root/.ollama
     deploy:


### PR DESCRIPTION
This PR brings some Docker compose and environment configuration updates aimed at enhancing the flexibility and clarity of the Docker setup for the local cat:

- Added missing restart policies for Ollama
- Rearranged existing environment variables in .env.example to enhance configuration clarity and ease of use
- Introduced some useful environment variables in .env.example for Ollama 
- Refactor docker file with semicolons and quoting values for enhanced YAML parsing safety 
  - This change also makes the file similar to configmaps used by orchestration platforms like Kubernetes, easing porting
- Updated .gitignore to include .env file, preventing sensitive or local configuration data from being tracked 