### PR TITLE
Docker compose to run local cat with docker + exernal ollama service with GPU acceleration

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,9 @@ A ready to use 100% local setup for Cat + Ollama + Embedder + Qdrant
    4. ollama GPU based
 2. one command setup
    1. self-download the LLM (somehow)
+
+## Use Ollama with MacOS GPU Acceleration
+
+Ollama normally handles running the model with GPU acceleration. In order to use GPU acceleration on Mac OS it is recommended to run Ollama alongside Docker Desktop. More info [here](https://ollama.com/blog/ollama-is-now-available-as-an-official-docker-image).
+This mean that to use local-cat you have to install the classic (and recommended) menu bar app version of Ollama and run a multi-container docker application that run only the cat-code and qdrant containers.
+To do this use the file `docker-compose-macos.yml` for creating your docker app. Before running the `docker-compose up` command, edit the file located in `cat/data/metadata.json`, find the URL `http://ollama:11434` and replace it with the following one `http://host.docker.internal:11434`. This will allow docker's containers to send requests to your local ollama service while enjoying the GPU acceleration.

--- a/docker-compose-macos.yml
+++ b/docker-compose-macos.yml
@@ -1,0 +1,38 @@
+version: '3.7'
+
+services:
+  cheshire-cat-core:
+    image: ghcr.io/cheshire-cat-ai/core:1.6.2
+    container_name: cheshire_cat_core
+    depends_on:
+      - cheshire-cat-vector-memory
+    environment:
+      - PYTHONUNBUFFERED=1
+      - WATCHFILES_FORCE_POLLING=true
+      - CORE_HOST=${CORE_HOST:-localhost}
+      - CORE_PORT=${CORE_PORT:-1865}
+      - QDRANT_HOST=${QDRANT_HOST:-cheshire_cat_vector_memory}
+      - QDRANT_PORT=${QDRANT_PORT:-6333}
+      - CORE_USE_SECURE_PROTOCOLS=${CORE_USE_SECURE_PROTOCOLS:-}
+      - API_KEY=${API_KEY:-}
+      - LOG_LEVEL=${LOG_LEVEL:-WARNING}
+      - DEBUG=${DEBUG:-true}
+      - SAVE_MEMORY_SNAPSHOTS=${SAVE_MEMORY_SNAPSHOTS:-false}
+    ports:
+      - ${CORE_PORT:-1865}:80
+    volumes:
+      - ./cat/static:/app/cat/static
+      - ./cat/plugins:/app/cat/plugins
+      - ./cat/data:/app/cat/data
+    restart: unless-stopped
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  cheshire-cat-vector-memory:
+    image: qdrant/qdrant:v1.9.1
+    container_name: cheshire_cat_vector_memory
+    expose:
+      - 6333
+    volumes:
+      - ./cat/long_term_memory/vector:/qdrant/storage
+    restart: unless-stopped


### PR DESCRIPTION
Created new docker compose file to support native GPU acceleration on MacOS whille running the non-docker version of Ollama. 
Updated the README file with quick instructions when running the new docker compose on mac os.